### PR TITLE
Remove Styled Components SPEEDY MODE from Sanity CLI config

### DIFF
--- a/studio/sanity.cli.ts
+++ b/studio/sanity.cli.ts
@@ -6,7 +6,6 @@
  */
 
 import {defineCliConfig} from 'sanity/cli'
-import {type UserConfig} from 'vite'
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'your-projectID'
 const dataset = process.env.SANITY_STUDIO_DATASET || 'production'

--- a/studio/sanity.cli.ts
+++ b/studio/sanity.cli.ts
@@ -1,3 +1,10 @@
+/**
+ * Sanity CLI Configuration
+ * This file configures the Sanity CLI tool with project-specific settings
+ * and customizes the Vite bundler configuration.
+ * Learn more: https://www.sanity.io/docs/cli
+ */
+
 import {defineCliConfig} from 'sanity/cli'
 import {type UserConfig} from 'vite'
 
@@ -8,15 +15,5 @@ export default defineCliConfig({
   api: {
     projectId,
     dataset,
-  },
-  vite(viteConfig: UserConfig): UserConfig {
-    return {
-      ...viteConfig,
-      define: {
-        ...viteConfig.define,
-        // `sanity dev` enables speedy in both development and production, this line restores the default `styled-components` behaviour of only enabling it in production
-        'process.env.SC_DISABLE_SPEEDY': JSON.stringify(process.env.NODE_ENV !== 'production'),
-      },
-    }
   },
 })


### PR DESCRIPTION
Remove Styled Components SPEEDY MODE from Sanity CLI config as it's no longer needed and `sanity dev` is now setting these env vars by default