### PR TITLE
Exports and structure refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://template-nextjs-clean.sanity.dev
 
 ## Getting Started
 
-### Install the template
+### Installing the template
 
 #### 1. Initialize template with Sanity CLI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14850,6 +14850,7 @@
         "@sanity/icons": "^3.5.0",
         "@sanity/vision": "^3.65.1",
         "date-fns": "^3.6.0",
+        "pluralize-esm": "^9.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rxjs": "^7.8.1",

--- a/studio/package.json
+++ b/studio/package.json
@@ -20,6 +20,7 @@
     "@sanity/icons": "^3.5.0",
     "@sanity/vision": "^3.65.1",
     "date-fns": "^3.6.0",
+    "pluralize-esm": "^9.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rxjs": "^7.8.1",

--- a/studio/src/schemaTypes/documents/page.ts
+++ b/studio/src/schemaTypes/documents/page.ts
@@ -6,7 +6,7 @@ import {DocumentIcon} from '@sanity/icons'
  * Learn more: https://www.sanity.io/docs/schema-types
  */
 
-export default defineType({
+export const page = defineType({
   name: 'page',
   title: 'Page',
   type: 'document',

--- a/studio/src/schemaTypes/documents/person.ts
+++ b/studio/src/schemaTypes/documents/person.ts
@@ -6,7 +6,7 @@ import {defineField, defineType} from 'sanity'
  * Learn more: https://www.sanity.io/docs/schema-types
  */
 
-export default defineType({
+export const person = defineType({
   name: 'person',
   title: 'Person',
   icon: UserIcon,

--- a/studio/src/schemaTypes/documents/post.ts
+++ b/studio/src/schemaTypes/documents/post.ts
@@ -7,7 +7,7 @@ import {defineField, defineType} from 'sanity'
  * Learn more: https://www.sanity.io/docs/schema-types
  */
 
-export default defineType({
+export const post = defineType({
   name: 'post',
   title: 'Post',
   icon: DocumentTextIcon,

--- a/studio/src/schemaTypes/index.ts
+++ b/studio/src/schemaTypes/index.ts
@@ -1,11 +1,11 @@
-import person from './documents/person'
-import page from './documents/page'
-import post from './documents/post'
-import callToAction from './objects/callToAction'
-import infoSection from './objects/infoSection'
-import settings from './singletons/settings'
-import link from './objects/link'
-import blockContent from './objects/blockContent'
+import {person} from './documents/person'
+import {page} from './documents/page'
+import {post} from './documents/post'
+import {callToAction} from './objects/callToAction'
+import {infoSection} from './objects/infoSection'
+import {settings} from './singletons/settings'
+import {link} from './objects/link'
+import {blockContent} from './objects/blockContent'
 
 // Export an array of all the schema types.  This is used in the Sanity Studio configuration. https://www.sanity.io/docs/schema-types
 

--- a/studio/src/schemaTypes/objects/blockContent.tsx
+++ b/studio/src/schemaTypes/objects/blockContent.tsx
@@ -12,7 +12,7 @@ import {defineArrayMember, defineType, defineField} from 'sanity'
  *
  * Learn more: https://www.sanity.io/docs/block-content
  */
-export default defineType({
+export const blockContent = defineType({
   title: 'Block Content',
   name: 'blockContent',
   type: 'array',

--- a/studio/src/schemaTypes/objects/callToAction.ts
+++ b/studio/src/schemaTypes/objects/callToAction.ts
@@ -6,7 +6,7 @@ import {BulbOutlineIcon} from '@sanity/icons'
  * Learn more: https://www.sanity.io/docs/object-type
  */
 
-export default defineType({
+export const callToAction = defineType({
   name: 'callToAction',
   title: 'Call to Action',
   type: 'object',

--- a/studio/src/schemaTypes/objects/infoSection.ts
+++ b/studio/src/schemaTypes/objects/infoSection.ts
@@ -1,7 +1,7 @@
 import {defineField, defineType} from 'sanity'
 import {TextIcon} from '@sanity/icons'
 
-export default defineType({
+export const infoSection = defineType({
   name: 'infoSection',
   title: 'Info Section',
   type: 'object',

--- a/studio/src/schemaTypes/objects/link.ts
+++ b/studio/src/schemaTypes/objects/link.ts
@@ -7,7 +7,7 @@ import {LinkIcon} from '@sanity/icons'
  * Learn more: https://www.sanity.io/docs/object-type
  */
 
-export default defineType({
+export const link = defineType({
   name: 'link',
   title: 'Link',
   type: 'object',

--- a/studio/src/schemaTypes/singletons/settings.tsx
+++ b/studio/src/schemaTypes/singletons/settings.tsx
@@ -8,7 +8,7 @@ import * as demo from '../../lib/initialValues'
  * Learn more: https://www.sanity.io/docs/create-a-link-to-a-single-edit-page-in-your-main-document-type-list
  */
 
-export default defineType({
+export const settings = defineType({
   name: 'settings',
   title: 'Settings',
   type: 'document',

--- a/studio/src/structure/index.ts
+++ b/studio/src/structure/index.ts
@@ -1,5 +1,6 @@
 import {CogIcon} from '@sanity/icons'
 import type {StructureBuilder, StructureResolver} from 'sanity/structure'
+import pluralize from 'pluralize-esm'
 
 /**
  * Structure builder is useful whenever you want to control how documents are grouped and
@@ -13,10 +14,13 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
   S.list()
     .title('Website Content')
     .items([
-      ...S.documentTypeListItems().filter(
+      ...S.documentTypeListItems()
         // Remove the "assist.instruction.context" and "settings" content  from the list of content types
-        (listItem: any) => !DISABLED_TYPES.includes(listItem.getId()),
-      ),
+        .filter((listItem: any) => !DISABLED_TYPES.includes(listItem.getId()))
+        // Pluralize the title of each document type.  This is not required but just an option to consider.
+        .map((listItem) => {
+          return listItem.title(pluralize(listItem.getTitle() as string))
+        }),
       // Settings Singleton in order to view/edit the one particular document for Settings.  Learn more about Singletons: https://www.sanity.io/docs/create-a-link-to-a-single-edit-page-in-your-main-document-type-list
       S.listItem()
         .title('Site Settings')

--- a/studio/src/structure/index.ts
+++ b/studio/src/structure/index.ts
@@ -1,5 +1,5 @@
 import {CogIcon} from '@sanity/icons'
-import type {StructureResolver} from 'sanity/structure'
+import type {StructureBuilder, StructureResolver} from 'sanity/structure'
 
 /**
  * Structure builder is useful whenever you want to control how documents are grouped and
@@ -7,14 +7,33 @@ import type {StructureResolver} from 'sanity/structure'
  * Learn more: https://www.sanity.io/docs/structure-builder-introduction
  */
 
-export const structure: StructureResolver = (S: any) =>
+// export const structure: StructureResolver = (S: any) =>
+//   S.list()
+//     .title('Website Content')
+//     .items([
+//       S.documentTypeListItem('post').title('Posts'),
+//       S.documentTypeListItem('page').title('Pages'),
+//       S.documentTypeListItem('person').title('People'),
+//       // Settings Singleton in order to view/edit the one particular document for Settings.  Learn more about Singletons: https://www.sanity.io/docs/create-a-link-to-a-single-edit-page-in-your-main-document-type-list
+//       S.listItem()
+//         .title('Site Settings')
+//         .child(S.document().schemaType('settings').documentId('siteSettings'))
+//         .icon(CogIcon),
+//     ])
+
+// ./deskStructure.js
+// import {CogIcon} from '@sanity/icons'
+
+const DISABLED_TYPES = ['settings', 'assist.instruction.context']
+
+export const structure: StructureResolver = (S: StructureBuilder) =>
   S.list()
     .title('Website Content')
     .items([
-      S.documentTypeListItem('post').title('Posts'),
-      S.documentTypeListItem('page').title('Pages'),
-      S.documentTypeListItem('person').title('People'),
-      // Settings Singleton in order to view/edit the one particular document for Settings.  Learn more about Singletons: https://www.sanity.io/docs/create-a-link-to-a-single-edit-page-in-your-main-document-type-list
+      ...S.documentTypeListItems().filter(
+        // Remove the "assist.instruction.context" and "settings" content  from the list of content types
+        (listItem: any) => !DISABLED_TYPES.includes(listItem.getId()),
+      ),
       S.listItem()
         .title('Site Settings')
         .child(S.document().schemaType('settings').documentId('siteSettings'))

--- a/studio/src/structure/index.ts
+++ b/studio/src/structure/index.ts
@@ -7,23 +7,6 @@ import type {StructureBuilder, StructureResolver} from 'sanity/structure'
  * Learn more: https://www.sanity.io/docs/structure-builder-introduction
  */
 
-// export const structure: StructureResolver = (S: any) =>
-//   S.list()
-//     .title('Website Content')
-//     .items([
-//       S.documentTypeListItem('post').title('Posts'),
-//       S.documentTypeListItem('page').title('Pages'),
-//       S.documentTypeListItem('person').title('People'),
-//       // Settings Singleton in order to view/edit the one particular document for Settings.  Learn more about Singletons: https://www.sanity.io/docs/create-a-link-to-a-single-edit-page-in-your-main-document-type-list
-//       S.listItem()
-//         .title('Site Settings')
-//         .child(S.document().schemaType('settings').documentId('siteSettings'))
-//         .icon(CogIcon),
-//     ])
-
-// ./deskStructure.js
-// import {CogIcon} from '@sanity/icons'
-
 const DISABLED_TYPES = ['settings', 'assist.instruction.context']
 
 export const structure: StructureResolver = (S: StructureBuilder) =>
@@ -34,6 +17,7 @@ export const structure: StructureResolver = (S: StructureBuilder) =>
         // Remove the "assist.instruction.context" and "settings" content  from the list of content types
         (listItem: any) => !DISABLED_TYPES.includes(listItem.getId()),
       ),
+      // Settings Singleton in order to view/edit the one particular document for Settings.  Learn more about Singletons: https://www.sanity.io/docs/create-a-link-to-a-single-edit-page-in-your-main-document-type-list
       S.listItem()
         .title('Site Settings')
         .child(S.document().schemaType('settings').documentId('siteSettings'))


### PR DESCRIPTION
This commit if updates:

- Avoids the "export default" pattern and uses named exports as they are better for auto imports.
- Updates the structure to include all schema types by default and excludes what we don't want.  This is better because new schema types will be added to the structure by default.