### PR TITLE
Update Sanity client to accept token for private dataset utilization

### DIFF
--- a/nextjs-app/sanity/lib/client.ts
+++ b/nextjs-app/sanity/lib/client.ts
@@ -9,7 +9,7 @@ export const client = createClient({
   apiVersion,
   useCdn: true,
   perspective: "published",
-  token: token, // Required if you have a private dataset
+  token, // Required if you have a private dataset
   stega: {
     studioUrl,
     // Set logger to 'console' for more verbose logging

--- a/nextjs-app/sanity/lib/client.ts
+++ b/nextjs-app/sanity/lib/client.ts
@@ -1,6 +1,7 @@
 import { createClient } from "next-sanity";
 
 import { apiVersion, dataset, projectId, studioUrl } from "@/sanity/lib/api";
+import { token } from "./token";
 
 export const client = createClient({
   projectId,
@@ -8,6 +9,7 @@ export const client = createClient({
   apiVersion,
   useCdn: true,
   perspective: "published",
+  token: token, // Required if you have a private dataset
   stega: {
     studioUrl,
     // Set logger to 'console' for more verbose logging


### PR DESCRIPTION
Add configuration to the frontend app, to pull in the read-token, enabling private datasets