### PR TITLE
Run schema extraction in predev for typegen to work correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "sanity-template-nextjs-clean",
   "description": "Next.js + Sanity: A Powerful Website Starter with Real-time Visual Editing",
   "scripts": {
+    "predev": "npm run schema:extract",
+    "schema:extract": "cd studio && sanity schema extract",
     "dev": "npm-run-all --parallel --print-label dev:*",
     "dev:next": "npm run dev --workspace=frontend",
     "dev:studio": "npm run dev --workspace=studio",


### PR DESCRIPTION

### Description

Typegen from the frontend next application will currently not pick up any new sanity schema changes automatically (this drove me nuts for a couple of hours). This predev step will automatically run the schema extraction so typegen will not miss any new type definitions in /frontend.

### What to review

predev step in package.json

### Testing

Tested locally