### PR TITLE
Add dismissible notification banner

### DIFF
--- a/frontend/app/components/NotificationBanner.tsx
+++ b/frontend/app/components/NotificationBanner.tsx
@@ -37,23 +37,22 @@ export default function NotificationBanner() {
   const storageKey = notification ? `notification-dismissed-${notification.id}` : ''
 
   const [show, setShow] = useState(false)
-  const [mounted, setMounted] = useState(() => {
-    if (!notification) return false
-    try {
-      return !localStorage.getItem(storageKey)
-    } catch {
-      return false
-    }
-  })
+  const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    if (!mounted) return
-    // Delay so the 0fr state is painted before we transition to 1fr
+    if (!notification) return
+    try {
+      if (localStorage.getItem(storageKey)) return
+    } catch {
+      return
+    }
+    // Set mounted inside rAF to avoid synchronous setState in effect
     const timer = requestAnimationFrame(() => {
+      setMounted(true)
       requestAnimationFrame(() => setShow(true))
     })
     return () => cancelAnimationFrame(timer)
-  }, [mounted])
+  }, [storageKey])
 
   const dismiss = useCallback(() => {
     setShow(false)

--- a/frontend/app/components/NotificationBanner.tsx
+++ b/frontend/app/components/NotificationBanner.tsx
@@ -34,26 +34,26 @@ function getNotification(): {id: string; message: string} | null {
 const notification = getNotification()
 
 export default function NotificationBanner() {
-  const [show, setShow] = useState(false)
-  const [mounted, setMounted] = useState(false)
-
   const storageKey = notification ? `notification-dismissed-${notification.id}` : ''
 
-  useEffect(() => {
-    if (!notification) return
+  const [show, setShow] = useState(false)
+  const [mounted, setMounted] = useState(() => {
+    if (!notification) return false
     try {
-      if (!localStorage.getItem(storageKey)) {
-        setMounted(true)
-        // Delay so the 0fr state is painted before we transition to 1fr
-        const timer = requestAnimationFrame(() => {
-          requestAnimationFrame(() => setShow(true))
-        })
-        return () => cancelAnimationFrame(timer)
-      }
+      return !localStorage.getItem(storageKey)
     } catch {
-      // localStorage unavailable
+      return false
     }
-  }, [storageKey])
+  })
+
+  useEffect(() => {
+    if (!mounted) return
+    // Delay so the 0fr state is painted before we transition to 1fr
+    const timer = requestAnimationFrame(() => {
+      requestAnimationFrame(() => setShow(true))
+    })
+    return () => cancelAnimationFrame(timer)
+  }, [mounted])
 
   const dismiss = useCallback(() => {
     setShow(false)

--- a/frontend/app/components/NotificationBanner.tsx
+++ b/frontend/app/components/NotificationBanner.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import {useState, useEffect, useCallback} from 'react'
+
+function parseMarkdown(md: string): string {
+  let html = md
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(
+      /\[(.+?)\]\((https?:\/\/.+?)\)/g,
+      '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>',
+    )
+
+  // Sanitize: strip script tags and event handler attributes
+  html = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+  html = html.replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '')
+
+  return html
+}
+
+function getNotification(): {id: string; message: string} | null {
+  try {
+    const raw = process.env.SANITY_TEMPLATE_NOTIFICATION
+    if (!raw) return null
+    const n = JSON.parse(raw)
+    if (n?.enabled && n?.id && n?.message) {
+      return {id: n.id, message: n.message}
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+const notification = getNotification()
+
+export default function NotificationBanner() {
+  const [show, setShow] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  const storageKey = notification ? `notification-dismissed-${notification.id}` : ''
+
+  useEffect(() => {
+    if (!notification) return
+    try {
+      if (!localStorage.getItem(storageKey)) {
+        setMounted(true)
+        // Delay so the 0fr state is painted before we transition to 1fr
+        const timer = requestAnimationFrame(() => {
+          requestAnimationFrame(() => setShow(true))
+        })
+        return () => cancelAnimationFrame(timer)
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }, [storageKey])
+
+  const dismiss = useCallback(() => {
+    setShow(false)
+    try {
+      localStorage.setItem(storageKey, '1')
+    } catch {
+      // localStorage unavailable
+    }
+  }, [storageKey])
+
+  if (!notification || !mounted) return null
+
+  const html = parseMarkdown(notification.message)
+
+  return (
+    <div
+      role="status"
+      className="grid transition-[grid-template-rows] duration-300 ease-out"
+      style={{gridTemplateRows: show ? '1fr' : '0fr'}}
+      onTransitionEnd={() => {
+        if (!show) setMounted(false)
+      }}
+    >
+      <div className="overflow-hidden">
+        <div className="bg-blue-600 px-4 py-3 text-white">
+          <div className="mx-auto text-center flex max-w-7xl items-center justify-center gap-4">
+            <div
+              className="text-sm [&_a]:underline [&_strong]:font-bold"
+              dangerouslySetInnerHTML={{__html: html}}
+            />
+            <button
+              onClick={dismiss}
+              aria-label="Dismiss notification"
+              className="shrink-0 rounded p-1 hover:bg-blue-700"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -16,6 +16,8 @@ import {sanityFetch, SanityLive} from '@/sanity/lib/live'
 import {settingsQuery} from '@/sanity/lib/queries'
 import {resolveOpenGraphImage} from '@/sanity/lib/utils'
 import {handleError} from '@/app/client-utils'
+// The NotificationBanner component is responsible for rendering a notification banner at the top of the page, based on the contents of sanity-template.json. It checks if a notification is enabled and if the user has dismissed it before rendering the banner.  It is safe to remove.
+import NotificationBanner from '@/app/components/NotificationBanner'
 
 /**
  * Generate metadata for the page.
@@ -74,6 +76,7 @@ export default async function RootLayout({children}: {children: React.ReactNode}
         <section className="min-h-screen pt-24">
           {/* The <Toaster> component is responsible for rendering toast notifications used in /app/client-utils.ts and /app/components/DraftModeToast.tsx */}
           <Toaster />
+          <NotificationBanner />
           {isDraftMode && (
             <>
               <DraftModeToast />

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,9 +1,23 @@
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
 import type {NextConfig} from 'next'
 
 const nextConfig: NextConfig = {
   env: {
     // Matches the behavior of `sanity dev` which sets styled-components to use the fastest way of inserting CSS rules in both dev and production. It's default behavior is to disable it in dev mode.
     SC_DISABLE_SPEEDY: 'false',
+    // Read the notification config from sanity-template.json at startup so the
+    // NotificationBanner client component can access it via process.env.
+    SANITY_TEMPLATE_NOTIFICATION: (() => {
+      try {
+        const raw = readFileSync(resolve(process.cwd(), '..', 'sanity-template.json'), 'utf-8')
+        const notification = JSON.parse(raw)?.notification
+        return notification ? JSON.stringify(notification) : ''
+      } catch {
+        return ''
+      }
+    })(),
   },
   images: {
     remotePatterns: [new URL('https://cdn.sanity.io/**')],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18498,7 +18498,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "format": "prettier --cache --write .",
     "import-sample-data": "cd studio && sanity dataset import sample-data.tar.gz --replace",
     "lint": "npm run lint --workspace=frontend",
-    "type-check": "npm run type-check --workspaces"
+    "type-check": "npm run type-check --workspaces",
+    "disable-notification": "node scripts/disable-notification.mjs"
   },
   "prettier": "@sanity/prettier-config",
   "devDependencies": {

--- a/sanity-template.json
+++ b/sanity-template.json
@@ -3,6 +3,6 @@
   "notification": {
     "id": "getting-started",
     "enabled": true,
-    "message": "**Build AI features powered by your content.** Create assistants and bots that read your Sanity content. [Get started with Agent Context](https://www.sanity.io/docs/ai/agent-context)"
+    "message": "**Ship AI features that actually know your content.** Agent Context gives any MCP-compatible agent schema-aware access to your dataset. [Get started →](https://www.sanity.io/docs/ai/agent-context)"
   }
 }

--- a/sanity-template.json
+++ b/sanity-template.json
@@ -1,0 +1,8 @@
+{
+  "postInitMessage": "POST MESSAGE",
+  "notification": {
+    "id": "getting-started",
+    "enabled": true,
+    "message": "**Build AI features powered by your content.** Create assistants and bots that read your Sanity content. [Get started with Agent Context](https://www.sanity.io/docs/ai/agent-context)"
+  }
+}

--- a/scripts/disable-notification.mjs
+++ b/scripts/disable-notification.mjs
@@ -1,0 +1,16 @@
+import {readFileSync, writeFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
+const filePath = resolve(process.cwd(), 'sanity-template.json')
+
+try {
+  const data = JSON.parse(readFileSync(filePath, 'utf-8'))
+  if (data.notification) {
+    data.notification.enabled = false
+  }
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n')
+  console.log('Notification disabled in sanity-template.json')
+} catch (err) {
+  console.error('Could not disable notification:', err.message)
+  process.exit(1)
+}

--- a/scripts/disable-notification.mjs
+++ b/scripts/disable-notification.mjs
@@ -10,6 +10,7 @@ try {
   }
   writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n')
   console.log('Notification disabled in sanity-template.json')
+  console.log('Restart the dev server for this change to take effect.')
 } catch (err) {
   console.error('Could not disable notification:', err.message)
   process.exit(1)


### PR DESCRIPTION
## Summary
- Adds a configurable notification banner driven by `sanity-template.json`
- Banner supports basic markdown (bold text, links) and persists dismissal via localStorage
- Initial message promotes [Agent Context](https://www.sanity.io/docs/ai/agent-context) for building AI-powered features with Sanity content
- Includes `npm run disable-notification` script to turn off the banner

<img width="2536" height="1784" alt="image" src="https://github.com/user-attachments/assets/faaeebce-aeef-45eb-a61e-c2e19f83fcd8" />
Current banner says: **Ship AI features that actually know your content.** Agent Context gives any MCP-compatible agent schema-aware access to your dataset. [Get started →](https://www.sanity.io/docs/ai/agent-context)

## How it works
- `sanity-template.json` defines the notification config (`id`, `enabled`, `message`)
- `next.config.ts` reads the file at build time and injects it as `process.env.SANITY_TEMPLATE_NOTIFICATION`
- `NotificationBanner.tsx` is a client component that renders the banner with a height animation and dismiss button

## Test plan
- [ ] Verify banner appears on page load
- [ ] Verify dismiss button hides the banner and it stays hidden on refresh
- [ ] Clear localStorage key `notification-dismissed-getting-started` and verify it reappears
- [ ] Run `npm run disable-notification` and verify the banner no longer appears
- [ ] Set `enabled: false` in `sanity-template.json` and verify no banner renders